### PR TITLE
scratch: show Insomniak47 the VersionTagParser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +588,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,7 +685,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "conventional",
+ "lazy_static",
+ "regex",
  "reqwest",
+ "semver",
  "serde",
  "tokio",
 ]
@@ -686,6 +715,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.1.1", features = ["cargo", "env", "unicode", "wrap_help"] }
 conventional = "0.5.0"
+lazy_static = "1.4.0"
+regex = "1.7.1"
 reqwest = { version = "0.11.13", features = ["json"]}
+semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"]}
 tokio = { version = "1.24.2", features = ["rt-multi-thread", "macros"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,15 +4,21 @@ use std::collections::HashMap;
 
 use clap::{arg, command, Command};
 use conventional::Simple;
+use lazy_static::lazy_static;
+use regex::Regex;
 use reqwest::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let matches = command!()
+
+    let mut cmd = command!()
+        // todo: validate base is a version or "latest"
         // todo: support detecting current repo and/or using a config file
         .arg(arg!(--owner <OWNER> "The owner of the GitHub repo").required(true))
         .arg(arg!(--repo <REPO> "The name of the GitHub repo").required(true))
-        .arg(arg!(--base <RELEASE_TAG> "The tag name of the GitHub release to use as a base (defaults to latest)"))
+        .arg(arg!(--base <RELEASE_TAG> "The tag name of the GitHub release to use as a base (defaults to latest)")
+            .required(true)
+            .value_parser(VersionTagParser{}))
         .arg(arg!(--target <REF> "The git ref to generate release info for").default_value("HEAD"))
         // todo: investigate the impact of propagate_version -- do subcommands need to have versions?
         .subcommand(
@@ -23,10 +29,15 @@ async fn main() -> Result<(), Error> {
             Command::new("changelog")
                 .about("Generates the changelog")
         )
-        .arg_required_else_help(true)
         .max_term_width(100)
-        .help_expected(true)
-        .get_matches();
+        .help_expected(true);
+
+    // note: Calling render_help after get_matches doesn't work because it attempts to borrow a moved value. I don't
+    // understand why render_help borrows and get_matches moves. The intention here is to have the default subcommand
+    // be help but I didn't find anything in clap about default subcommands so here we are.
+    let help_text = cmd.render_help();
+
+    let matches = cmd.get_matches();
 
     let client = reqwest::Client::new();
     let context = github::Context::new(
@@ -35,9 +46,13 @@ async fn main() -> Result<(), Error> {
         matches.get_one::<String>("repo").unwrap(),
     );
 
+    // note: This doesn't actually make sense. The parser for --base should confirm that we can get a version from the
+    // string, not actually convert to a version. Since we may or may not have a 'v' prefix it's not safe to assume we
+    // do; I'm just getting away with it because we're only testing against peer. I left this in just because I wanted
+    // to show Insomniak47 the impl of VersionTagParser from before I realized this was a mistake.
     let release = matches
-        .get_one::<String>("base")
-        .map_or("latest".into(), |x| format!("tags/{}", x));
+        .get_one::<semver::Version>("base")
+        .map_or("latest".into(), |x| format!("tags/v{}", x.to_string()));
 
     let release = context.get_release(&release).await?;
 
@@ -56,8 +71,11 @@ async fn main() -> Result<(), Error> {
         .collect::<Vec<_>>();
 
     match matches.subcommand() {
-        Some(("version", _)) => println!("You typed version :D"),
+        Some(("version", _)) => print_version(matches.get_one::<semver::Version>("base").unwrap(), &commits),
         Some(("changelog", _)) => print_changelog(&commits),
+        None => {
+            println!("{}", help_text);
+        }
         _ => unreachable!("Oh nooo"),
     };
 
@@ -66,6 +84,23 @@ async fn main() -> Result<(), Error> {
 
 fn is_relevant_commit(commit: &conventional::Commit) -> bool {
     commit.type_() == "feat" || commit.type_() == "fix"
+}
+
+fn print_version(base: &semver::Version, commits: &Vec<conventional::Commit>) {
+    println!("{}", get_version(base, commits));
+}
+
+fn get_version(base: &semver::Version, commits: &Vec<conventional::Commit>) -> semver::Version {
+    if commits.iter().any(|x| x.breaking()) {
+        return semver::Version::new(base.major + 1, 0, 0);
+    }
+    if commits.iter().any(|x| x.type_() == "feat") {
+        return semver::Version::new(base.major, base.minor + 1, 0);
+    }
+    if commits.iter().any(|x| x.type_() == "fix") {
+        return semver::Version::new(base.major, base.minor, base.patch + 1);
+    }
+    base.to_owned()
 }
 
 fn print_changelog(commits: &Vec<conventional::Commit>) {
@@ -105,4 +140,59 @@ fn print_category(
             println!("{subject}", subject = commit.description())
         }
     }
+}
+
+#[derive(Clone)]
+struct VersionTagParser;
+
+impl VersionTagParser {
+    fn make_error(cmd: &clap::Command, arg: Option<&clap::Arg>, value: &str) -> clap::Error {
+        let mut err = clap::Error::new(clap::error::ErrorKind::ValueValidation).with_cmd(cmd);
+        if let Some(arg) = arg {
+            err.insert(clap::error::ContextKind::InvalidArg, clap::error::ContextValue::String(arg.to_string()));
+        }
+        err.insert(clap::error::ContextKind::InvalidValue, clap::error::ContextValue::String(value.to_owned()));
+        err
+    }
+}
+
+impl clap::builder::TypedValueParser for VersionTagParser {
+
+    type Value = semver::Version;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+
+        lazy_static! {
+            static ref RE: Regex = Regex::new(r"^v?(?P<version>\d+\.\d+\.\d+)$").unwrap();
+        }
+
+        let arg_value = value.to_string_lossy();
+
+        let result = RE
+            .captures(&arg_value)
+            .map(|x| x.name("version"))
+            .flatten()
+            .map(|x| x.as_str())
+            .map(|x| semver::Version::parse(x))
+            .ok_or_else(|| VersionTagParser::make_error(cmd, arg, &arg_value))
+            .map(|x| {
+                x.map_err(|e| {
+                    let mut err = VersionTagParser::make_error(cmd, arg, &arg_value);
+                    err.insert(clap::error::ContextKind::Custom, clap::error::ContextValue::String(e.to_string()));
+                    err
+                })
+            });
+
+        match result {
+            Ok(Ok(x)) => Ok(x),
+            Ok(x) => x,
+            Err(x) => Err(x),
+        }
+    }
+
 }


### PR DESCRIPTION
I lost the plot a bit when I made the --base option parse a Version instead of just confirming that a version COULD be extracted from it; but the code is interesting so I'm sharing it anyway. What should actually happen is we should confirm that we're able to extract a version but keep the passed argument as a string because we need to use it in the URI of the request for the release. We only want to pull the version out to use as the base when calculating the new version for the version subcommand.